### PR TITLE
Fix documents page

### DIFF
--- a/front/src/app/components/documents/documents.component.html
+++ b/front/src/app/components/documents/documents.component.html
@@ -19,6 +19,23 @@
     <p id="line"></p>
 
     <div id="container">
+        <span class="item">
+            <img class="item-image" src="../../../assets/images/plus.png"/>
+            <p class="folder-name">New folder</p>
+        </span>
+        <!-- folders will be dispayed first and documents after -->
+        <span class="item" *ngFor="let i of folderNames;" (dblclick)="openFolder(i)">
+            <img class="item-image" src="../../../assets/images/folder.png"/>
+            <div class="hover-element">
+                <!-- <span><img class="option" src="../../../assets/images/open_folder.png" (click)="openFolder(i)"/></span> -->
+                <span><img class="option" src="../../../assets/images/add-group.png" (click)="addPeople()"/></span>
+                <span><img class="option" src="../../../assets/images/trash.png" (click)="openDialog()"/></span>
+            </div>
+            <div class="tooltip">
+                <p class="folder-name">{{ i }}</p>
+                <p class="tooltiptext">{{ i }}</p>
+            </div>
+        </span>
         <span class="item" *ngFor="let i of documentsNames;" (dblclick)="openFile(i)">
             <img class="item-image" [src]="choosePicture(i)"/>
             <div class="hover-element">

--- a/front/src/app/components/documents/documents.component.ts
+++ b/front/src/app/components/documents/documents.component.ts
@@ -9,6 +9,9 @@ import { CognitoService } from 'src/app/services/cognito.service';
 })
 export class DocumentsComponent implements OnInit {
 
+  folderNames: string[] = ["Birthday picsss", "Me", "Friends", "Family", "Party", "New Years Eve", "Christmas", 
+  "Algorithms and data structures", "Movies", "Favorite TV Shows", "Cloud Computing"];
+
   documentsNames: string[] = ['file.pdf', 'picture.png', 'audio.mp3', 'video.mp4', 'word.docx', 'picture2.jpg', 'picture3.jpeg'];
 
   constructor(private router: Router, private cognitoService: CognitoService) { }
@@ -29,6 +32,14 @@ export class DocumentsComponent implements OnInit {
         this.router.navigate(['/welcome-page']);
       }
     })
+  }
+
+  createNewFolder() {
+
+  }
+
+  openFolder(name: string) {
+    console.log(name);
   }
 
   openFile(name: string) {


### PR DESCRIPTION
- added folders on documents page
- view starts with all folders and that displays documents, let me know if this is fine
- back arrow need to be bound later (after service is created on frontend, or however it works)
- I did not delete folders page just in case
- closes #21 